### PR TITLE
Add missing `host` argument to argument reference in resource.md

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -27,6 +27,7 @@ resource "ssh_resource" "init" {
 
 The following arguments are supported:
 
+* `host` - (Required) The IP address or DNS hostname of the target server
 * `user` - (Required) The username to use for provision activities using SSH
 * `private_key` - (Required) The SSH private key to use for provision activities
 * `file` - (Optional) Block specifying content to be written to the container host after creation


### PR DESCRIPTION
`host` is provided in the example but was missing from the argument reference in the docs.