### PR TITLE
Enable support for SSH private key distinct from the bastion private …

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -6,10 +6,11 @@ The following example uses the internal provisioning support for bootstrapping a
 
 ```hcl
 resource "ssh_resource" "init" {
-  host         = "private-ec2.instance.com"
-  bastion_host = "bastion.host.com"
-  user         = var.user
-  private_key  = var.private_key
+  host              = "private-ec2.instance.com"
+  bastion_host      = "bastion.host.com"
+  user              = var.user
+  private_key       = var.private_key
+  host_private_key  = var.host_private_key
 
   file {
     content     = "echo Hello world"
@@ -30,6 +31,7 @@ The following arguments are supported:
 * `host` - (Required) The IP address or DNS hostname of the target server
 * `user` - (Required) The username to use for provision activities using SSH
 * `private_key` - (Required) The SSH private key to use for provision activities
+* `host_private_key` - (Optional) A distinct SSH private key to use for provision activities when provided. When missing the provided `private_key` is used
 * `file` - (Optional) Block specifying content to be written to the container host after creation
 * `commands` - (Required, list(string)) List of commands to execute after creation of container host
 * `bastion_host` - (Optional) The bastion host to use.  When not set, this will be deduced from the container host location

--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -52,10 +52,9 @@ func resourceResource() *schema.Resource {
 				RequiredWith: []string{"user"},
 			},
 			"host_private_key": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				RequiredWith: []string{"user"},
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"commands": {
 				Type:     schema.TypeList,

--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/loafoe/easyssh-proxy/v2"
 	"math/rand"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/loafoe/easyssh-proxy/v2"
 )
 
 func resourceResource() *schema.Resource {
@@ -45,6 +46,12 @@ func resourceResource() *schema.Resource {
 				ForceNew:     true,
 			},
 			"private_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"user"},
+			},
+			"host_private_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
@@ -111,8 +118,13 @@ func resourceResourceUpdate(_ context.Context, d *schema.ResourceData, m interfa
 	bastionHost := d.Get("bastion_host").(string)
 	user := d.Get("user").(string)
 	privateKey := d.Get("private_key").(string)
+	hostPrivateKey := d.Get("host_private_key").(string)
 	host := d.Get("host").(string)
 	commandsAfterFileChanges := d.Get("commands_after_file_changes").(bool)
+
+	if len(hostPrivateKey) == 0 {
+		hostPrivateKey = privateKey
+	}
 
 	// Collect SSH details
 	privateIP := host
@@ -120,7 +132,7 @@ func resourceResourceUpdate(_ context.Context, d *schema.ResourceData, m interfa
 		User:   user,
 		Server: privateIP,
 		Port:   "22",
-		Key:    privateKey,
+		Key:    hostPrivateKey,
 		Proxy:  http.ProxyFromEnvironment,
 		Bastion: easyssh.DefaultConfig{
 			User:   user,
@@ -170,7 +182,12 @@ func resourceResourceCreate(_ context.Context, d *schema.ResourceData, m interfa
 	bastionHost := d.Get("bastion_host").(string)
 	user := d.Get("user").(string)
 	privateKey := d.Get("private_key").(string)
+	hostPrivateKey := d.Get("host_private_key").(string)
 	host := d.Get("host").(string)
+
+	if len(hostPrivateKey) == 0 {
+		hostPrivateKey = privateKey
+	}
 
 	// Fetch files first before starting provisioning
 	createFiles, diags := collectFilesToCreate(d)
@@ -196,7 +213,7 @@ func resourceResourceCreate(_ context.Context, d *schema.ResourceData, m interfa
 		User:   user,
 		Server: privateIP,
 		Port:   "22",
-		Key:    privateKey,
+		Key:    hostPrivateKey,
 		Proxy:  http.ProxyFromEnvironment,
 		Bastion: easyssh.DefaultConfig{
 			User:   user,


### PR DESCRIPTION
…key to connect to the host

* Add `host_private_key` to the resource schema
* Update function`resourceResourceCreate` to check & use the `host_private_key` when provided
* Update function `resourceResourceUpdate` to check & use the `host_private_key` when provided
* Update file `docs/resources/resource.md` to include the `host_private_key` in the example