### PR TITLE
Enable support for username distinct from the bastion username to connect to the host

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -9,6 +9,7 @@ resource "ssh_resource" "init" {
   host              = "private-ec2.instance.com"
   bastion_host      = "bastion.host.com"
   user              = var.user
+  host_user         = var.host_user
   private_key       = var.private_key
   host_private_key  = var.host_private_key
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -30,6 +30,7 @@ The following arguments are supported:
 
 * `host` - (Required) The IP address or DNS hostname of the target server
 * `user` - (Required) The username to use for provision activities using SSH
+* `host_user` - (Required) A distinct username to use for provision activities when provided. When missing the provided `user` is used
 * `private_key` - (Required) The SSH private key to use for provision activities
 * `host_private_key` - (Optional) A distinct SSH private key to use for provision activities when provided. When missing the provided `private_key` is used
 * `file` - (Optional) Block specifying content to be written to the container host after creation

--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -45,6 +45,11 @@ func resourceResource() *schema.Resource {
 				RequiredWith: []string{"private_key"},
 				ForceNew:     true,
 			},
+			"host_user": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"private_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -116,10 +121,15 @@ func resourceResourceUpdate(_ context.Context, d *schema.ResourceData, m interfa
 
 	bastionHost := d.Get("bastion_host").(string)
 	user := d.Get("user").(string)
+	hostUser := d.Get("host_user").(string)
 	privateKey := d.Get("private_key").(string)
 	hostPrivateKey := d.Get("host_private_key").(string)
 	host := d.Get("host").(string)
 	commandsAfterFileChanges := d.Get("commands_after_file_changes").(bool)
+
+	if len(hostUser) == 0 {
+		hostUser = user
+	}
 
 	if len(hostPrivateKey) == 0 {
 		hostPrivateKey = privateKey
@@ -128,7 +138,7 @@ func resourceResourceUpdate(_ context.Context, d *schema.ResourceData, m interfa
 	// Collect SSH details
 	privateIP := host
 	ssh := &easyssh.MakeConfig{
-		User:   user,
+		User:   hostUser,
 		Server: privateIP,
 		Port:   "22",
 		Key:    hostPrivateKey,
@@ -180,9 +190,14 @@ func resourceResourceCreate(_ context.Context, d *schema.ResourceData, m interfa
 
 	bastionHost := d.Get("bastion_host").(string)
 	user := d.Get("user").(string)
+	hostUser := d.Get("host_user").(string)
 	privateKey := d.Get("private_key").(string)
 	hostPrivateKey := d.Get("host_private_key").(string)
 	host := d.Get("host").(string)
+
+	if len(hostUser) == 0 {
+		hostUser = user
+	}
 
 	if len(hostPrivateKey) == 0 {
 		hostPrivateKey = privateKey
@@ -209,7 +224,7 @@ func resourceResourceCreate(_ context.Context, d *schema.ResourceData, m interfa
 	// Collect SSH details
 	privateIP := host
 	ssh := &easyssh.MakeConfig{
-		User:   user,
+		User:   hostUser,
 		Server: privateIP,
 		Port:   "22",
 		Key:    hostPrivateKey,


### PR DESCRIPTION
* Add `host_user` to the resource schema
* Update function `resourceResourceCreate` to check & use the `host_user` when provided
* Update function `resourceResourceUpdate` to check & use the `host_user` when provided
* Update file `docs/resources/resource.md` to include the `host_user` in the example