### PR TITLE
Add `ssh_destroy_resource`

### DIFF
--- a/docs/resources/destroy_resource.md
+++ b/docs/resources/destroy_resource.md
@@ -1,0 +1,65 @@
+# ssh_destroy_resource
+
+Supports copying and running commands over an
+SSH connection when being destroyed.
+
+The following example uses the internal provisioning support for bootstrapping an instance
+
+```hcl
+resource "ssh_destroy_resource" "destroy" {
+  host              = "private-ec2.instance.com"
+  bastion_host      = "bastion.host.com"
+  user              = var.user
+  host_user         = var.host_user
+  agent             = true
+  # An ssh-agent with your SSH private keys should be running
+  # Use 'private_key' to set the SSH key otherwise
+
+  file {
+    content     = "echo Hello world"
+    destination = "/tmp/hello.sh"
+    permissions = "0700"
+  }
+
+  timeout = "15m"
+
+  commands = [
+    "/tmp/hello.sh"
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host` - (Required) The IP address or DNS hostname of the target server
+* `user` - (Required) The username to use for provision activities using SSH
+* `host_user` - (Optional) A distinct username to use for provision activities when provided. When missing the provided `user` is used
+* `private_key` - (Optional) The SSH private key to use for provision activities. Recommend to use ssh-agent
+* `host_private_key` - (Optional) A distinct SSH private key to use for provision activities when provided. Recommend to use ssh-agent
+* `port` - (Optional) The SSH port to use on the target server. Default: `"22"`
+* `agent` - (Optional) Enforce the use of an SSH-agent. When set, will error in case a private key is provided. Default: 'false'
+* `file` - (Optional) Block specifying content to be written to the container host after creation
+* `commands` - (Required, list(string)) List of commands to execute after creation of container host
+* `bastion_host` - (Optional) The bastion host to use.  When not set, this will be deduced from the container host location
+* `bastion_port` - (Optional) The SSH port to use on the bastion host. Default: `"22"`
+* `triggers` - (Optional, list(string)) An list of strings which when changes will trigger recreation of the resource triggering
+  all create files and commands executions.
+* `commands_after_file_changes` - (Optional, bool) Re-run all commands after file changes. Default is `true`.
+* `timeout` - (Optional) Time to wait before considering a command to have timed out. Default is `5m`. Accept seconds (e.g. `180s`) or minutes (e.g. `30m`)
+
+Each `file` block can contain the following fields. Use either `content` or `source`:
+
+* `source` - (Optional, file path) Content of the file. Conflicts with `content`
+* `content` - (Optional, string) Content of the file. Conflicts with `source`
+* `destination` - (Required, string) Remote filename to store the content in
+* `permissions` - (Optional, string) The file permissions. Default permissions are "0644"
+* `owner` - (Optional, string) The file owner. Default owner the SSH user
+* `group` - (Optional, string) The file group. Default group is the SSH user's group
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID

--- a/ssh/resource_destroy_resource.go
+++ b/ssh/resource_destroy_resource.go
@@ -1,0 +1,35 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDestroyResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		CreateContext: resourceDestroyResourceCreate,
+		ReadContext:   schema.NoopContext,
+		UpdateContext: schema.NoopContext,
+		DeleteContext: resourceDestroyResourceDelete,
+		Schema:        resourceSchema,
+	}
+}
+
+func resourceDestroyResourceDelete(c context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	diags := resourceResourceCreate(c, d, m)
+	d.SetId("")
+	return diags
+}
+
+func resourceDestroyResourceCreate(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	d.SetId(fmt.Sprintf("%d", rand.Int()))
+	return diags
+}

--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -14,6 +14,112 @@ import (
 	"github.com/loafoe/easyssh-proxy/v2"
 )
 
+var resourceSchema map[string]*schema.Schema = map[string]*schema.Schema{
+	"triggers": {
+		Description: "A map of arbitrary strings that, when changed, will force the 'hsdp_container_host_exec' resource to be replaced, re-running any associated commands.",
+		Type:        schema.TypeMap,
+		Optional:    true,
+		ForceNew:    true,
+	},
+	"host": {
+		Type:     schema.TypeString,
+		Required: true,
+		ForceNew: true,
+	},
+	"port": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "22",
+	},
+	"bastion_host": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"bastion_port": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "22",
+	},
+	"user": {
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+	},
+	"host_user": {
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+	},
+	"private_key": {
+		Type:      schema.TypeString,
+		Optional:  true,
+		Sensitive: true,
+	},
+	"host_private_key": {
+		Type:      schema.TypeString,
+		Optional:  true,
+		Sensitive: true,
+	},
+	"agent": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"commands": {
+		Type:     schema.TypeList,
+		MaxItems: 100,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+		ForceNew: true,
+	},
+	"commands_after_file_changes": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"timeout": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "5m",
+	},
+	"result": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"file": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"source": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"content": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"destination": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"permissions": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"owner": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"group": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	},
+}
+
 func resourceResource() *schema.Resource {
 	return &schema.Resource{
 		Importer: &schema.ResourceImporter{
@@ -23,111 +129,7 @@ func resourceResource() *schema.Resource {
 		ReadContext:   resourceResourceRead,
 		UpdateContext: resourceResourceUpdate,
 		DeleteContext: resourceResourceDelete,
-		Schema: map[string]*schema.Schema{
-			"triggers": {
-				Description: "A map of arbitrary strings that, when changed, will force the 'hsdp_container_host_exec' resource to be replaced, re-running any associated commands.",
-				Type:        schema.TypeMap,
-				Optional:    true,
-				ForceNew:    true,
-			},
-			"host": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"port": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "22",
-			},
-			"bastion_host": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"bastion_port": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "22",
-			},
-			"user": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"host_user": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"private_key": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
-			},
-			"host_private_key": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
-			},
-			"agent": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"commands": {
-				Type:     schema.TypeList,
-				MaxItems: 100,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNew: true,
-			},
-			"commands_after_file_changes": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"timeout": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "5m",
-			},
-			"result": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"file": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"source": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"content": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"destination": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"permissions": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"owner": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"group": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-		},
+		Schema:        resourceSchema,
 	}
 }
 


### PR DESCRIPTION
Adds a new resource named `ssh_destroy_resource` which acts exactly like `ssh_resource`, but only runs during destroy. The destroy functionality reuses the schema and functions from `ssh_resource`.

The create function stores the empty state with a unique ID. Read and update operations are no-ops. 

Closes #37 