### PR TITLE
Feature: provide optional password to ssh config

### DIFF
--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -100,7 +100,7 @@ func sshResourceSchema(sensitive bool) map[string]*schema.Schema {
 		},
 		"password": {
 			Type:     schema.TypeString,
-			Optional: true
+			Optional: true,
 		},
 		"private_key": {
 			Type:      schema.TypeString,

--- a/ssh/resource_resource.go
+++ b/ssh/resource_resource.go
@@ -98,6 +98,10 @@ func sshResourceSchema(sensitive bool) map[string]*schema.Schema {
 			Optional: true,
 			ForceNew: true,
 		},
+		"password": {
+			Type:     schema.TypeString,
+			Optional: true
+		},
 		"private_key": {
 			Type:      schema.TypeString,
 			Optional:  true,
@@ -262,6 +266,7 @@ func mainRun(_ context.Context, d *schema.ResourceData, m interface{}, onUpdate 
 	bastionHost := d.Get("bastion_host").(string)
 	user := d.Get("user").(string)
 	hostUser := d.Get("host_user").(string)
+	password := d.Get("password").(string)
 	privateKey := d.Get("private_key").(string)
 	hostPrivateKey := d.Get("host_private_key").(string)
 	host := d.Get("host").(string)
@@ -308,6 +313,9 @@ func mainRun(_ context.Context, d *schema.ResourceData, m interface{}, onUpdate 
 			Server: bastionHost,
 			Port:   bastionPort,
 		},
+	}
+	if password != ""{
+		ssh.Password = password
 	}
 	if hostPrivateKey != "" {
 		ssh.Key = hostPrivateKey


### PR DESCRIPTION
**NOT TESTED**
**ATTENTION, PLEASE CHECK BEFORE MERGING**

Adding an optional password attribute seemed very straight forward. I just looked up how other attributes were handled and added a new attribute named password. I hope it really is as easy as it seemed and works the way I thought it would.

**However this was the first time I saw Go code so please double check.**
Also there were some things I wasn't quite sure about:
1. Should I use a `Sensitive` or `ForceNew` tag as I don't know what they do?
2. Should I add the password attribute to `resource_resource_vX.go` as well or just to `resource_resource.go`?
3. Not sure if I should make sure that only one, either password or private key is used for authentication. If I should do it, I don't know how to.