### PR TITLE
Add retry limit

### DIFF
--- a/ssh/resource_resource_v3.go
+++ b/ssh/resource_resource_v3.go
@@ -11,12 +11,13 @@ func patchResourceV3(_ context.Context, rawState map[string]interface{}, _ inter
 	if rawState == nil {
 		rawState = map[string]interface{}{}
 	}
+	rawState["retry_limit"] = 5
 	return rawState, nil
 }
 
 func resourceResourceV3() *schema.Resource {
 	return &schema.Resource{
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 		Schema: map[string]*schema.Schema{
 			"when": {
 				Description:  "Determines when the commands is to be executed. Options are 'create' or 'destroy'",


### PR DESCRIPTION
I find that for many of my scripts runtime errors are not recoverable (especially during development where they might just be caused by something simple like invalid syntax/paths/etc), and retrying until the timeout is hit is really just a waste of time. To avoid this I've added a retry limit so you can tell the provider to just give up after x attempts.

I might be misunderstanding how the resource versioning/SchemaVersion system works, but as far as I could tell v3 of the resource did not introduce any actual changes, nor did it actually bump the SchemaVersion, so I just put my changes in that version and bumped the version. Please let me know if this is incorrect.